### PR TITLE
Add skeleton for launch-json to get --help.

### DIFF
--- a/bin/launch-json/Main.hs
+++ b/bin/launch-json/Main.hs
@@ -1,4 +1,6 @@
 module Main (main) where
 
+import qualified LaunchJson (main)
+
 main :: IO ()
-main = putStrLn "launch-json"
+main = LaunchJson.main

--- a/launch-json.cabal
+++ b/launch-json.cabal
@@ -35,7 +35,9 @@ source-repository head
 
 common launch-json-common
   build-depends:
-    base ^>=4.16.3.0 || ^>=4.17 || ^>=4.18 || ^>=4.19 || ^>=4.20
+    , base                  ^>=4.16.3.0  || ^>=4.17    || ^>=4.18 || ^>=4.19 || ^>=4.20
+    , filepath              ^>=1.4.100.1 || ^>=1.5.3.0
+    , optparse-applicative  ^>=0.18.1.0
 
   ghc-options:
     -Wall -Werror=missing-fields -Werror=unused-imports
@@ -44,9 +46,20 @@ common launch-json-common
 
 library launch-json-library
   import:           launch-json-common
-  exposed-modules:  Launch.Json
+  exposed-modules:
+    LaunchJson
+    LaunchJson.Defaults
+    LaunchJson.Environment
+    LaunchJson.Options
+
   other-modules:
   build-depends:
+    , exceptions    ^>=0.10.7
+    , Glob          ^>=0.10.2
+    , monad-logger  ^>=0.3.40
+    , mtl           ^>=2.3.1
+    , process       ^>=1.6.17.0
+
   hs-source-dirs:   lib/launch-json
   default-language: Haskell2010
 
@@ -54,10 +67,17 @@ test-suite launch-json-test
   import:           launch-json-common
   type:             exitcode-stdio-1.0
   main-is:          Main.hs
-  build-depends:    tasty ^>=1.4.3 || ^>=1.5
+  build-depends:
+    , hspec                ^>=2.11.9
+    , launch-json-library
+    , tasty                ^>=1.4.3   || ^>=1.5
+    , tasty-hspec          ^>=1.2.0.4
+    , text                 ^>=2.0.2   || ^>=2.1
 
-  -- , launch-json-library
   other-modules:
+    LaunchJsonSpec
+    LaunchJsonSpec.OptionsSpec
+
   hs-source-dirs:   test/launch-json
   default-language: Haskell2010
   ghc-options:      -threaded
@@ -65,9 +85,8 @@ test-suite launch-json-test
 executable launch-json
   main-is:          Main.hs
   build-depends:
-    base ^>=4.16.3.0 || ^>=4.17.0.0 || ^>=4.18.0.0 || ^>=4.19.0.0 || ^>=4.20
-
-  -- , launch-json-library
+    , base                 ^>=4.16.3.0 || ^>=4.17.0.0 || ^>=4.18.0.0 || ^>=4.19.0.0 || ^>=4.20
+    , launch-json-library
 
   hs-source-dirs:   bin/launch-json
   default-language: Haskell2010

--- a/lib/launch-json/Launch/Json.hs
+++ b/lib/launch-json/Launch/Json.hs
@@ -1,1 +1,0 @@
-module Launch.Json () where

--- a/lib/launch-json/LaunchJson.hs
+++ b/lib/launch-json/LaunchJson.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module LaunchJson (main) where
+
+import Control.Monad.Catch (MonadThrow)
+import Control.Monad.Logger (LoggingT, MonadLogger, runStderrLoggingT)
+import Control.Monad.Reader (MonadIO, MonadReader, ReaderT, runReaderT)
+import qualified LaunchJson.Defaults (determine)
+import qualified LaunchJson.Environment (T)
+import qualified LaunchJson.Options (parserInfo)
+import Options.Applicative (execParser)
+
+newtype LaunchJson a = LaunchJson
+  { run :: LoggingT (ReaderT LaunchJson.Environment.T IO) a
+  }
+  deriving (Applicative, Functor, Monad, MonadIO, MonadLogger, MonadReader LaunchJson.Environment.T, MonadThrow)
+
+runLaunchJson :: LaunchJson a -> LaunchJson.Environment.T -> IO a
+runLaunchJson launchJson = runReaderT (runStderrLoggingT $ run launchJson)
+
+main :: IO ()
+main = LaunchJson.Defaults.determine >>= execParser . LaunchJson.Options.parserInfo >>= runLaunchJson main'
+
+main' :: LaunchJson ()
+main' = undefined
+
+-- Read Cabal file
+-- Generate launch.json
+-- Write launch.json to .vscode/launch.json

--- a/lib/launch-json/LaunchJson/Defaults.hs
+++ b/lib/launch-json/LaunchJson/Defaults.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module LaunchJson.Defaults (T (..), determine) where
+
+import Control.Monad ((<=<))
+import Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
+import Data.Maybe (listToMaybe)
+import System.FilePath.Glob (compile, globDir1)
+import System.OsPath (OsPath, decodeFS, encodeFS, encodeUtf)
+import System.Process (readProcess)
+
+data T = T
+  { dCabal :: Maybe OsPath,
+    dVisualStudioCode :: Maybe OsPath
+  }
+
+determine :: IO T
+determine = do
+  root' <- root >>= decodeFS
+  dCabal <- find "*.cabal" root'
+  dVisualStudioCode <- find ".vscode" root'
+  return T {..}
+  where
+    find glob path = (encodeUtf <=< listToMaybe) <$> globDir1 (compile glob) path
+
+root :: IO OsPath
+root = do
+  output <- nonEmpty . lines <$> readProcess "git" ["rev-parse", "--show-toplevel"] ""
+  case output of
+    Just (x :| _) -> encodeFS x
+    Nothing -> fail "`git rev-parse --show-toplevel` returned no output"

--- a/lib/launch-json/LaunchJson/Environment.hs
+++ b/lib/launch-json/LaunchJson/Environment.hs
@@ -1,0 +1,9 @@
+module LaunchJson.Environment (T (..)) where
+
+import System.OsPath (OsPath)
+
+data T = T
+  { cabal :: OsPath,
+    vscode :: OsPath
+  }
+  deriving (Show)

--- a/lib/launch-json/LaunchJson/Options.hs
+++ b/lib/launch-json/LaunchJson/Options.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module LaunchJson.Options (parserInfo) where
+
+import Control.Applicative ((<**>))
+import Control.Monad ((>=>))
+import LaunchJson.Defaults (T (dVisualStudioCode))
+import qualified LaunchJson.Defaults (T (..))
+import qualified LaunchJson.Environment (T (..))
+import Options.Applicative
+  ( HasValue,
+    Mod,
+    Parser,
+    ParserInfo,
+    ReadM,
+    fullDesc,
+    help,
+    helper,
+    info,
+    long,
+    maybeReader,
+    metavar,
+    option,
+    progDesc,
+    showDefault,
+    value,
+  )
+import System.OsPath (OsPath, encodeUtf, isValid)
+
+parserInfo :: LaunchJson.Defaults.T -> Options.Applicative.ParserInfo LaunchJson.Environment.T
+parserInfo ds =
+  info
+    (parser ds <**> helper)
+    ( fullDesc
+        <> progDesc
+          ( unlines
+              [ "Create launch.json in VSCODE for CABAL"
+              ]
+          )
+    )
+
+parser :: LaunchJson.Defaults.T -> Options.Applicative.Parser LaunchJson.Environment.T
+parser LaunchJson.Defaults.T {..} = do
+  cabal <-
+    option
+      path
+      ( long "cabal-path"
+          <> help "Path to cabal file used as source for launch.json."
+          <> metavar "CABAL"
+          <> maybeDefault dCabal
+      )
+  vscode <-
+    option
+      path
+      ( long "vscode-path"
+          <> help "Path to vscode directory used as target for launch.json."
+          <> metavar "VSCODE"
+          <> maybeDefault dVisualStudioCode
+      )
+  pure LaunchJson.Environment.T {..}
+
+path :: Options.Applicative.ReadM System.OsPath.OsPath
+path = maybeReader (encodeUtf >=> \p -> if isValid p then Just p else Nothing)
+
+maybeDefault :: (HasValue f, Show a) => Maybe a -> Mod f a
+maybeDefault (Just a) = value a <> showDefault
+maybeDefault Nothing = mempty

--- a/test/launch-json/LaunchJsonSpec.hs
+++ b/test/launch-json/LaunchJsonSpec.hs
@@ -1,0 +1,8 @@
+module LaunchJsonSpec (spec) where
+
+import qualified LaunchJsonSpec.OptionsSpec (spec)
+import Test.Hspec (Spec, describe)
+
+spec :: Spec
+spec = describe "LaunchJson" $ do
+  LaunchJsonSpec.OptionsSpec.spec

--- a/test/launch-json/LaunchJsonSpec/OptionsSpec.hs
+++ b/test/launch-json/LaunchJsonSpec/OptionsSpec.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module LaunchJsonSpec.OptionsSpec (spec) where
+
+import Data.Text (Text, isInfixOf, pack)
+import LaunchJson.Defaults (T (..))
+import qualified LaunchJson.Environment (T)
+import qualified LaunchJson.Options as SUT
+import Options.Applicative
+  ( ParserResult (CompletionInvoked, Failure, Success),
+    defaultPrefs,
+    execParserPure,
+    renderFailure,
+  )
+import System.Exit (ExitCode (ExitFailure, ExitSuccess))
+import System.OsPath (encodeUtf)
+import Test.Hspec (Spec, describe, it, shouldSatisfy)
+
+spec :: Spec
+spec = describe "Options" $ do
+  describe "parserInfo" $ do
+    it "should error if --cabal-path is \"\"" $
+      parse ["--cabal-path", ""]
+        `shouldSatisfy` failWith
+          "option --cabal-path: cannot parse value `'"
+    it "should error if --vscode-path is \"\"" $
+      parse ["--vscode-path", ""]
+        `shouldSatisfy` failWith
+          "option --vscode-path: cannot parse value `'"
+
+failWith :: Text -> ParserResult a -> Bool
+failWith _ (Success _) = False
+failWith _ (CompletionInvoked _) = False
+failWith m (Failure f) =
+  case renderFailure f "" of
+    (_, ExitSuccess) -> False
+    (m', ExitFailure _) -> m `isInfixOf` pack m'
+
+parse :: [String] -> ParserResult LaunchJson.Environment.T
+parse = execParserPure defaultPrefs (SUT.parserInfo defaults)
+
+defaults :: LaunchJson.Defaults.T
+defaults =
+  LaunchJson.Defaults.T
+    { dCabal = encodeUtf "default",
+      dVisualStudioCode = encodeUtf "default"
+    }

--- a/test/launch-json/Main.hs
+++ b/test/launch-json/Main.hs
@@ -1,6 +1,14 @@
 module Main (main) where
 
+import qualified LaunchJsonSpec (spec)
 import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.Hspec (testSpec)
 
 main :: IO ()
-main = defaultMain $ testGroup "launch-json-library" []
+main = do
+  specs <- testSpec "hspec" LaunchJsonSpec.spec
+  defaultMain $
+    testGroup
+      "launch-json-library"
+      [ specs
+      ]


### PR DESCRIPTION
This adds two known options (cabal and vscode paths) so that the --help option functions. Further pull requests will flesh out the actual actions.