### PR TITLE
Add launch-configuration library

### DIFF
--- a/lib/launch-configuration/LaunchConfiguration.hs
+++ b/lib/launch-configuration/LaunchConfiguration.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module LaunchConfiguration (LaunchConfiguration, fromPath) where
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Aeson (ToJSON (toJSON), object, (.=))
+import Data.Map (Map)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import System.OsPath (OsPath, decodeUtf, encodeFS)
+
+-- |
+--  launch.json configuration for Haskell
+--
+--  = References
+--
+--  - [Visual Studio Code Marketplace Haskell GHCi Debug Adapter Phoityne](https://marketplace.visualstudio.com/items?itemName=phoityne.phoityne-vscode)
+--  - [Further examples](https://github.com/phoityne/hdx4vsc/tree/master/configs)
+data LaunchConfiguration = LaunchConfiguration
+  { -- | type of launch configuration; should be "ghc"
+    --   Example: "ghc"
+    configType :: LaunchConfigurationType,
+    -- | type of request; should be "launch"
+    --   Example: "launch"
+    request :: LaunchConfigurationRequest,
+    -- | name of the configuration; appears in the drop-down list on the Debug viewlet
+    --   Example: "haskell(cabal)"
+    name :: Text,
+    -- | internal console options; controls the visibility of the internal debug console
+    --   Example: "openOnSessionStart"
+    internalConsoleOptions :: LaunchConfigurationInternalConsoleOptions,
+    -- | workspace folder
+    --   Example: "${workspaceFolder}"
+    workspace :: OsPath,
+    -- | debug startup file which will be loaded automatically
+    --   Example: "${workspaceFolder}/test/Spec.hs"
+    startup :: OsPath,
+    -- | debug startup function which will be run instead of main
+    --   Example: "main"
+    startupFunc :: Text,
+    -- | arguments for 'startupFunc' as a single string
+    --   Example: "arg1 arg2"
+    startupArgs :: Text,
+    -- | stop or not after the debugger is launched
+    --   Example: False
+    stopOnEntry :: Bool,
+    -- | main arguments as a single string
+    --   Example: "arg1 arg2"
+    mainArgs :: Text,
+    -- | GHCi command prompt
+    --   Example: "H>>= "
+    ghciPrompt :: Text,
+    -- | GHCi initial prompt; use this if you set a custom prompt in ~/.ghci
+    --   Example: "Prelude> "
+    ghciInitialPrompt :: Maybe Text,
+    -- | GHCi command to start the REPL
+    --  Example: "cabal repl --with-compiler ghci-dap --repl-no-load --builddir=${workspaceRoot}/.vscode/dist-cabal-repl launch-json-test"
+    ghciCmd :: Text,
+    -- | GHCi environment variables
+    --   Example: {}
+    ghciEnv :: Map Text Text,
+    -- | log file path
+    --   Example: "${workspaceRoot}/.vscode/phoityne.log"
+    logFile :: OsPath,
+    -- | log level
+    --   Example: "WARNING"
+    logLevel :: Text,
+    -- | force inspect scope variables
+    --   Example: False
+    forceInspect :: Bool
+  }
+  deriving (Show)
+
+--  = Example JSON configuration
+--
+--  {
+--    "type": "ghc",
+--    "request": "launch",
+--    "name": "haskell(cabal)",
+--    "internalConsoleOptions": "openOnSessionStart",
+--    "workspace": "${workspaceFolder}",
+--    "startup": "${workspaceFolder}/test/launch-json/Main.hs",
+--    "startupFunc": "",
+--    "startupArgs": "",
+--    "stopOnEntry": false,
+--    "mainArgs": "",
+--    "ghciPrompt": "H>>= ",
+--    "ghciInitialPrompt": "> ",
+--    "ghciCmd": "cabal repl --with-compiler ghci-dap --repl-no-load --builddir=${workspaceFolder}/.vscode/dist-cabal-repl launch-json-test",
+--    "ghciEnv": {},
+--    "logFile": "${workspaceFolder}/.vscode/launch-json-test.log",
+--    "logLevel": "DEBUG",
+--    "forceInspect": false
+--  }
+instance ToJSON LaunchConfiguration where
+  toJSON (LaunchConfiguration {..}) =
+    object
+      [ "type" .= toJSON configType,
+        "request" .= request,
+        "name" .= name,
+        "internalConsoleOptions" .= internalConsoleOptions,
+        "workspace" .= toJSON (decodeUtf workspace :: Maybe FilePath),
+        "startup" .= toJSON (decodeUtf startup :: Maybe FilePath),
+        "startupFunc" .= startupFunc,
+        "startupArgs" .= startupArgs,
+        "stopOnEntry" .= stopOnEntry,
+        "mainArgs" .= mainArgs,
+        "ghciPrompt" .= ghciPrompt,
+        "ghciInitialPrompt" .= ghciInitialPrompt,
+        "ghciCmd" .= ghciCmd,
+        "ghciEnv" .= ghciEnv,
+        "logFile" .= toJSON (decodeUtf logFile :: Maybe FilePath),
+        "logLevel" .= logLevel,
+        "forceInspect" .= forceInspect
+      ]
+
+-- Intentional singleton
+data LaunchConfigurationType = GHC deriving (Show, Generic, ToJSON)
+
+data LaunchConfigurationRequest {- TODO Attach | -} = Launch deriving (Show, Generic, ToJSON)
+
+data LaunchConfigurationInternalConsoleOptions
+  = NeverOpen
+  deriving
+    ( -- | OpenOnSessionStart
+      -- | OpenOnFirstSessionStart
+      Show,
+      Generic,
+      ToJSON
+    )
+
+fromPath :: (MonadIO m) => OsPath -> m [LaunchConfiguration]
+fromPath _ = do
+  let configType = GHC
+  let request = Launch
+  let name = ""
+  let internalConsoleOptions = NeverOpen
+  workspace <- liftIO $ encodeFS ""
+  startup <- liftIO $ encodeFS ""
+  let startupFunc = ""
+  let startupArgs = ""
+  let stopOnEntry = False
+  let mainArgs = ""
+  let ghciPrompt = ""
+  let ghciInitialPrompt = Nothing
+  let ghciCmd = ""
+  let ghciEnv = mempty
+  logFile <- liftIO $ encodeFS ""
+  let logLevel = ""
+  let forceInspect = False
+  pure [LaunchConfiguration {..}]

--- a/test/launch-configuration/LaunchConfigurationGolden.hs
+++ b/test/launch-configuration/LaunchConfigurationGolden.hs
@@ -1,0 +1,22 @@
+module LaunchConfigurationGolden (golden) where
+
+import Data.Yaml (encode)
+import qualified LaunchConfiguration as SUT
+import System.FilePath (takeBaseName, (-<.>))
+import System.OsPath (encodeFS)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Golden (findByExtension, goldenVsString)
+
+golden :: IO [TestTree]
+golden =
+  sequence
+    [ testGroup "encode <$> LaunchConfiguration.fromPath"
+        . map
+          ( \p ->
+              goldenVsString
+                (takeBaseName p)
+                (p -<.> ".yaml")
+                (encode <$> (SUT.fromPath =<< encodeFS p))
+          )
+        <$> findByExtension [".cabal"] "test/launch-configuration/data"
+    ]

--- a/test/launch-configuration/Main.hs
+++ b/test/launch-configuration/Main.hs
@@ -1,0 +1,11 @@
+module Main (main) where
+
+import qualified LaunchConfigurationGolden (golden)
+import Test.Tasty (defaultMain, testGroup)
+
+main :: IO ()
+main = do
+  defaultMain . testGroup "launch-configuration-library"
+    =<< sequence
+      [ testGroup "golden" <$> LaunchConfigurationGolden.golden
+      ]

--- a/test/launch-configuration/data/launch-json.cabal
+++ b/test/launch-configuration/data/launch-json.cabal
@@ -28,8 +28,6 @@ extra-source-files:
   .vscode/*.json
 
 data-files:
-  test/launch-configuration/data/*.cabal
-  test/launch-configuration/data/*.json
 
 source-repository head
   type:     git
@@ -37,8 +35,7 @@ source-repository head
 
 common launch-configuration-common
   build-depends:
-    , aeson  ^>=2.2.3.0
-    , base   ^>=4.16.3.0 || ^>=4.17 || ^>=4.18 || ^>=4.19 || ^>=4.20
+    base ^>=4.16.3.0 || ^>=4.17 || ^>=4.18 || ^>=4.19 || ^>=4.20
 
   ghc-options:
     -Wall -Werror=missing-fields -Werror=unused-imports
@@ -50,6 +47,7 @@ library launch-configuration-library
   exposed-modules:  LaunchConfiguration
   other-modules:
   build-depends:
+    , aeson       ^>=2.2.3.0
     , containers  ^>=0.7
     , filepath    ^>=1.4.100.1 || ^>=1.5.3.0
     , text        ^>=2.0.2     || ^>=2.1
@@ -63,11 +61,17 @@ test-suite launch-configuration-test
   main-is:          Main.hs
   build-depends:
     , filepath                      ^>=1.4.100.1 || ^>=1.5.3.0
+    , hspec                         ^>=2.11.9
     , launch-configuration-library
     , tasty                         ^>=1.4.3     || ^>=1.5
     , tasty-golden                  ^>=2.3.5
+    , tasty-hspec                   ^>=1.2.0.4
+    , yaml                          ^>=0.11.11.2
 
-  other-modules:    LaunchConfigurationGolden
+  other-modules:
+    LaunchConfigurationGolden
+    LaunchConfigurationSpec
+
   hs-source-dirs:   test/launch-configuration
   default-language: Haskell2010
   ghc-options:      -threaded

--- a/test/launch-configuration/data/luanch-json.yaml
+++ b/test/launch-configuration/data/luanch-json.yaml
@@ -1,0 +1,35 @@
+- forceInspect: false
+  ghciCmd: cabal repl --with-compiler ghci-dap --repl-no-load --builddir=${workspace}/.vscode/dist-cabal-repl launch-configuration-test
+  ghciEnv: {}
+  ghciInitialPrompt: "> "
+  ghciPrompt: "H>>= "
+  internalConsoleOptions: openOnSessionStart
+  logFile: ${workspaceFolder}/.vscode/launch-configuration-test.log
+  logLevel: DEBUG
+  mainArgs: ""
+  name: launch-configuration-test
+  request: launch
+  startup: ${workspaceFolder}/test/launch-configuration/Main.hs
+  startupArgs: ""
+  startupFunc: ""
+  stopOnEntry: falsge
+  type: ghc
+  workspace: ${workspaceFolder}
+
+- forceInspect: false
+  ghciCmd: cabal repl --with-compiler ghci-dap --repl-no-load --builddir=${workspace}/.vscode/dist-cabal-repl launch-json-test
+  ghciEnv: {}
+  ghciInitialPrompt: "> "
+  ghciPrompt: "H>>= "
+  internalConsoleOptions: openOnSessionStart
+  logFile: ${workspaceFolder}/.vscode/launch-json-test.log
+  logLevel: DEBUG
+  mainArgs: ""
+  name: launch-json-test
+  request: launch
+  startup: ${workspaceFolder}/test/launch-json/Main.hs
+  startupArgs: ""
+  startupFunc: ""
+  stopOnEntry: false
+  type: ghc
+  workspace: ${workspaceFolder}


### PR DESCRIPTION
This new library allows for interactions with cabal files and the internal data format for the GHC style launch.json configuration objects.